### PR TITLE
chore: remove nodejs 16 shims

### DIFF
--- a/roundabout/globals.js
+++ b/roundabout/globals.js
@@ -1,8 +1,0 @@
-// NOTE: shim globals needed by content-claims client deps that would be present in nodejs v18.
-// TODO: migrate to sst v2 and nodejs v18+
-import { TransformStream, WritableStream, CountQueuingStrategy } from 'node:stream/web'
-import { fetch } from 'undici'
-globalThis.TransformStream = TransformStream
-globalThis.CountQueuingStrategy = CountQueuingStrategy
-globalThis.WritableStream = WritableStream
-globalThis.fetch = fetch

--- a/roundabout/piece.js
+++ b/roundabout/piece.js
@@ -1,7 +1,3 @@
-// NOTE: shim globals needed by content-claims client deps that would be present in nodejs v18.
-// TODO: migrate to sst v2 and nodejs v18+
-import './globals.js'
-
 import { read } from '@web3-storage/content-claims/client'
 
 import { PIECE_V1_CODE, PIECE_V1_MULTIHASH, PIECE_V2_MULTIHASH, RAW_CODE } from './constants.js'


### PR DESCRIPTION
We don't use node 16 anymore.