### PR TITLE
fix: add blob metrics

### DIFF
--- a/stacks/upload-api-stack.js
+++ b/stacks/upload-api-stack.js
@@ -174,8 +174,9 @@ export function UploadApiStack({ stack, app }) {
     environment: {
       ADMIN_METRICS_TABLE_NAME: adminMetricsTable.tableName,
       STORE_BUCKET_NAME: carparkBucket.bucketName,
+      ALLOCATION_TABLE_NAME: allocationTable.tableName
     },
-    permissions: [adminMetricsTable, carparkBucket],
+    permissions: [adminMetricsTable, carparkBucket, allocationTable],
     handler: 'upload-api/functions/admin-metrics.consumer',
     deadLetterQueue: uploadAdminMetricsDLQ.cdk.queue,
   })
@@ -185,8 +186,9 @@ export function UploadApiStack({ stack, app }) {
     environment: {
       SPACE_METRICS_TABLE_NAME: spaceMetricsTable.tableName,
       STORE_BUCKET_NAME: carparkBucket.bucketName,
+      ALLOCATION_TABLE_NAME: allocationTable.tableName
     },
-    permissions: [spaceMetricsTable, carparkBucket],
+    permissions: [spaceMetricsTable, carparkBucket, allocationTable],
     handler: 'upload-api/functions/space-metrics.consumer',
     deadLetterQueue: uploadSpaceMetricsDLQ.cdk.queue,
   })

--- a/upload-api/constants.js
+++ b/upload-api/constants.js
@@ -6,8 +6,14 @@ import {
   add as uploadAdd,
   remove as uploadRemove
 } from '@web3-storage/capabilities/upload'
+import {
+  add as blobAdd,
+  remove as blobRemove
+} from '@web3-storage/capabilities/blob'
 
 // UCAN protocol
+export const BLOB_ADD = blobAdd.can
+export const BLOB_REMOVE = blobRemove.can
 export const STORE_ADD = storeAdd.can
 export const STORE_REMOVE = storeRemove.can
 export const UPLOAD_ADD = uploadAdd.can
@@ -17,6 +23,10 @@ export const UPLOAD_REMOVE = uploadRemove.can
 export const METRICS_NAMES = {
   UPLOAD_ADD_TOTAL: `${UPLOAD_ADD}-total`,
   UPLOAD_REMOVE_TOTAL: `${UPLOAD_REMOVE}-total`,
+  BLOB_ADD_TOTAL: `${BLOB_ADD}-total`,
+  BLOB_ADD_SIZE_TOTAL: `${BLOB_ADD}-size-total`,
+  BLOB_REMOVE_TOTAL: `${BLOB_REMOVE}-total`,
+  BLOB_REMOVE_SIZE_TOTAL: `${BLOB_REMOVE}-size-total`,
   STORE_ADD_TOTAL: `${STORE_ADD}-total`,
   STORE_ADD_SIZE_TOTAL: `${STORE_ADD}-size-total`,
   STORE_REMOVE_TOTAL: `${STORE_REMOVE}-total`,
@@ -27,6 +37,10 @@ export const METRICS_NAMES = {
 export const SPACE_METRICS_NAMES = {
   UPLOAD_ADD_TOTAL: `${UPLOAD_ADD}-total`,
   UPLOAD_REMOVE_TOTAL: `${UPLOAD_REMOVE}-total`,
+  BLOB_ADD_TOTAL: `${BLOB_ADD}-total`,
+  BLOB_ADD_SIZE_TOTAL: `${BLOB_ADD}-size-total`,
+  BLOB_REMOVE_TOTAL: `${BLOB_REMOVE}-total`,
+  BLOB_REMOVE_SIZE_TOTAL: `${BLOB_REMOVE}-size-total`,
   STORE_ADD_TOTAL: `${STORE_ADD}-total`,
   STORE_ADD_SIZE_TOTAL: `${STORE_ADD}-size-total`,
   STORE_REMOVE_TOTAL: `${STORE_REMOVE}-total`,

--- a/upload-api/functions/admin-metrics.js
+++ b/upload-api/functions/admin-metrics.js
@@ -6,6 +6,7 @@ import * as DAGJson from '@ipld/dag-json'
 import { updateAdminMetrics } from '../metrics.js'
 import { createMetricsTable } from '../stores/metrics.js'
 import { createCarStore } from '../buckets/car-store.js'
+import { createAllocationsStorage } from '../stores/allocations.js'
 import { mustGetEnv } from './utils.js'
 
 Sentry.AWSLambda.init({
@@ -24,11 +25,13 @@ async function handler(event) {
   const {
     metricsTableName,
     storeBucketName,
+    allocationTableName,
   } = getLambdaEnv()
 
   await updateAdminMetrics(ucanInvocations, {
     metricsStore: createMetricsTable(AWS_REGION, metricsTableName),
     carStore: createCarStore(AWS_REGION, storeBucketName),
+    allocationsStorage: createAllocationsStorage(AWS_REGION, allocationTableName)
   })
 }
 
@@ -36,6 +39,7 @@ function getLambdaEnv () {
   return {
     metricsTableName: mustGetEnv('ADMIN_METRICS_TABLE_NAME'),
     storeBucketName: mustGetEnv('STORE_BUCKET_NAME'),
+    allocationTableName: mustGetEnv('ALLOCATION_TABLE_NAME'),
   }
 }
 

--- a/upload-api/functions/space-metrics.js
+++ b/upload-api/functions/space-metrics.js
@@ -6,6 +6,7 @@ import * as DAGJson from '@ipld/dag-json'
 import { updateSpaceMetrics } from '../metrics.js'
 import { createMetricsTable } from '../stores/space-metrics.js'
 import { createCarStore } from '../buckets/car-store.js'
+import { createAllocationsStorage } from '../stores/allocations.js'
 import { mustGetEnv } from './utils.js'
 
 Sentry.AWSLambda.init({
@@ -23,12 +24,14 @@ async function handler(event) {
   const ucanInvocations = parseKinesisEvent(event)
   const {
     metricsTableName,
-    storeBucketName
+    storeBucketName,
+    allocationTableName,
   } = getLambdaEnv()
 
   await updateSpaceMetrics(ucanInvocations, {
     metricsStore: createMetricsTable(AWS_REGION, metricsTableName),
     carStore: createCarStore(AWS_REGION, storeBucketName),
+    allocationsStorage: createAllocationsStorage(AWS_REGION, allocationTableName)
   })
 }
 
@@ -36,6 +39,7 @@ function getLambdaEnv () {
   return {
     storeBucketName: mustGetEnv('STORE_BUCKET_NAME'),
     metricsTableName: mustGetEnv('SPACE_METRICS_TABLE_NAME'),
+    allocationTableName: mustGetEnv('ALLOCATION_TABLE_NAME'),
   }
 }
 

--- a/upload-api/test/admin-metrics.test.js
+++ b/upload-api/test/admin-metrics.test.js
@@ -1,10 +1,9 @@
 import { testMetrics as test } from './helpers/context.js'
 
-import { PutObjectCommand } from '@aws-sdk/client-s3'
-import * as StoreCapabilities from '@web3-storage/capabilities/store'
+import * as BlobCapabilities from '@web3-storage/capabilities/blob'
 import * as UploadCapabilities from '@web3-storage/capabilities/upload'
 import * as Signer from '@ucanto/principal/ed25519'
-import { adminMetricsTableProps } from '../tables/index.js'
+import { adminMetricsTableProps, allocationTableProps } from '../tables/index.js'
 import { METRICS_NAMES } from '../constants.js'
 
 import {
@@ -14,11 +13,12 @@ import {
   createBucket
 } from './helpers/resources.js'
 import { createSpace } from './helpers/ucan.js'
-import { randomCAR } from './helpers/random.js'
+import { randomBlob, randomCAR } from './helpers/random.js'
 
 import { STREAM_TYPE } from '../ucan-invocation.js'
 import { useCarStore } from '../buckets/car-store.js'
 import { useMetricsTable } from '../stores/metrics.js'
+import { useAllocationsStorage } from '../stores/allocations.js'
 import { updateAdminMetrics } from '../metrics.js'
 import { useMetricsTable as useMetricsGetTable } from '../tables/metrics.js'
 import { getMetrics } from '../functions/metrics.js'
@@ -37,32 +37,36 @@ test.beforeEach(async t => {
   const { dynamo, s3 } = t.context
   const adminMetricsTableName = await createTable(dynamo, adminMetricsTableProps)
   const adminMetricsStore = useMetricsTable(dynamo, adminMetricsTableName)
+  const allocationsTableName = await createTable(dynamo, allocationTableProps)
+  const allocationsStorage = useAllocationsStorage(dynamo, allocationsTableName)
   const carStoreBucketName = await createBucket(s3)
   const carStore = useCarStore(s3, carStoreBucketName)
   Object.assign(t.context, {
     adminMetricsStore,
     adminMetricsTableName,
     carStore,
-    carStoreBucketName
+    carStoreBucketName,
+    allocationsStorage,
+    allocationsTableName
   })
 })
 
-test('handles a batch of single invocation with store/add', async t => {
-  const { adminMetricsStore, carStore } = t.context
+test('handles a batch of single invocation with blob/add', async t => {
+  const { adminMetricsStore, carStore, allocationsStorage } = t.context
   const uploadService = await Signer.generate()
   const alice = await Signer.generate()
   const { spaceDid } = await createSpace(alice)
+  const blob = await randomBlob(128)
   const car = await randomCAR(128)
 
   const invocations = [{
     carCid: car.cid.toString(),
     value: {
         att: [
-          StoreCapabilities.add.create({
+          BlobCapabilities.add.create({
             with: spaceDid,
             nb: {
-              link: car.cid,
-              size: car.size
+              blob
             }
           })
         ],
@@ -79,32 +83,33 @@ test('handles a batch of single invocation with store/add', async t => {
   // @ts-expect-error
   await updateAdminMetrics(invocations, {
     metricsStore: adminMetricsStore,
-    carStore
+    carStore,
+    allocationsStorage
   })
   const metricsTable = useMetricsGetTable(t.context.dynamo, t.context.adminMetricsTableName)
   const metrics = await getMetrics(metricsTable)
 
-  t.deepEqual(metrics[METRICS_NAMES.STORE_ADD_TOTAL], 1)
-  t.deepEqual(metrics[METRICS_NAMES.STORE_ADD_SIZE_TOTAL], car.size)
+  t.deepEqual(metrics[METRICS_NAMES.BLOB_ADD_TOTAL], 1)
+  t.deepEqual(metrics[METRICS_NAMES.BLOB_ADD_SIZE_TOTAL], blob.size)
 })
 
-test('handles batch of single invocations with multiple store/add attributes', async t => {
-  const { adminMetricsStore, carStore } = t.context
+test('handles batch of single invocations with multiple blob/add attributes', async t => {
+  const { adminMetricsStore, carStore, allocationsStorage } = t.context
   const uploadService = await Signer.generate()
   const alice = await Signer.generate()
   const { spaceDid } = await createSpace(alice)
-  const cars = await Promise.all(
-    Array.from({ length: 10 }).map(() => randomCAR(128))
+  const car = await randomCAR(128)
+  const blobs = await Promise.all(
+    Array.from({ length: 10 }).map(() => randomBlob(128))
   )
 
   const invocations = [{
-    carCid: cars[0].cid.toString(),
+    carCid: car.cid.toString(),
     value: {
-      att: cars.map((car) => StoreCapabilities.add.create({
+      att: blobs.map((blob) => BlobCapabilities.add.create({
         with: spaceDid,
         nb: {
-          link: car.cid,
-          size: car.size
+          blob
         }
       })),
       aud: uploadService.did(),
@@ -120,33 +125,34 @@ test('handles batch of single invocations with multiple store/add attributes', a
   // @ts-expect-error
   await updateAdminMetrics(invocations, {
     metricsStore: adminMetricsStore,
-    carStore
+    carStore,
+    allocationsStorage
   })
   const metricsTable = useMetricsGetTable(t.context.dynamo, t.context.adminMetricsTableName)
   const metrics = await getMetrics(metricsTable)
 
-  t.deepEqual(metrics[METRICS_NAMES.STORE_ADD_TOTAL], cars.length)
-  t.deepEqual(metrics[METRICS_NAMES.STORE_ADD_SIZE_TOTAL], cars.reduce((acc, c) => {
+  t.deepEqual(metrics[METRICS_NAMES.BLOB_ADD_TOTAL], blobs.length)
+  t.deepEqual(metrics[METRICS_NAMES.BLOB_ADD_SIZE_TOTAL], blobs.reduce((acc, c) => {
     return acc + c.size
   }, 0))
 })
 
-test('handles a batch of single invocation with store/add without receipt', async t => {
-  const { adminMetricsStore, carStore } = t.context
+test('handles a batch of single invocation with blob/add without receipt', async t => {
+  const { adminMetricsStore, carStore, allocationsStorage } = t.context
   const uploadService = await Signer.generate()
   const alice = await Signer.generate()
   const { spaceDid } = await createSpace(alice)
+  const blob = await randomBlob(128)
   const car = await randomCAR(128)
 
   const invocations = [{
     carCid: car.cid.toString(),
     value: {
         att: [
-          StoreCapabilities.add.create({
+          BlobCapabilities.add.create({
             with: spaceDid,
             nb: {
-              link: car.cid,
-              size: car.size
+              blob
             }
           })
         ],
@@ -163,45 +169,46 @@ test('handles a batch of single invocation with store/add without receipt', asyn
   // @ts-expect-error
   await updateAdminMetrics(invocations, {
     metricsStore: adminMetricsStore,
-    carStore
+    carStore,
+    allocationsStorage
   })
   const metricsTable = useMetricsGetTable(t.context.dynamo, t.context.adminMetricsTableName)
   const metrics = await getMetrics(metricsTable)
 
-  t.falsy(metrics[METRICS_NAMES.STORE_ADD_TOTAL])
-  t.falsy(metrics[METRICS_NAMES.STORE_ADD_SIZE_TOTAL])
+  t.falsy(metrics[METRICS_NAMES.BLOB_ADD_TOTAL])
+  t.falsy(metrics[METRICS_NAMES.BLOB_ADD_SIZE_TOTAL])
 })
 
 test('handles a batch of invocations with upload-api tracking capabilities', async t => {
-  const { adminMetricsStore, carStore, carStoreBucketName } = t.context
+  const { adminMetricsStore, carStore, allocationsStorage } = t.context
   const uploadService = await Signer.generate()
   const alice = await Signer.generate()
   const { spaceDid } = await createSpace(alice)
-  const cars = await Promise.all(
-    Array.from({ length: 3 }).map(() => randomCAR(128))
+  const car = await randomCAR(128)
+  const blobs = await Promise.all(
+    Array.from({ length: 3 }).map(() => randomBlob(128))
   )
-  // Put CARs to bucket
-  await Promise.all(cars.map(async car => {
-    const putObjectCmd = new PutObjectCommand({
-      Key: `${car.cid.toString()}/${car.cid.toString()}.car`,
-      Bucket: carStoreBucketName,
-      Body: Buffer.from(
-        await car.arrayBuffer()
-      )
+
+  // Allocate Blobs
+  await Promise.all(blobs.map(async blob => {
+    const allocateRes = await allocationsStorage.insert({
+      space: spaceDid,
+      cause: car.cid,
+      blob
     })
-    return t.context.s3.send(putObjectCmd)
+
+    t.truthy(allocateRes.ok)
   }))
 
   const invocations = [
-    // store/add
+    // blob/add
     {
-      carCid: cars[0].cid.toString(),
+      carCid: car.cid.toString(),
       value: {
-        att: cars.map((car) => StoreCapabilities.add.create({
+        att: blobs.map((blob) => BlobCapabilities.add.create({
           with: spaceDid,
           nb: {
-            link: car.cid,
-            size: car.size
+            blob
           }
         })),
         aud: uploadService.did(),
@@ -215,14 +222,14 @@ test('handles a batch of invocations with upload-api tracking capabilities', asy
     },
     // upload/add
     {
-      carCid: cars[0].cid.toString(),
+      carCid: car.cid.toString(),
       value: {
           att: [
             UploadCapabilities.add.create({
               with: spaceDid,
               nb: {
-                root: cars[0].cid,
-                shards: cars.map(car => car.cid)
+                root: blobs[0].cid,
+                shards: blobs.map(blob => car.cid)
               }
             })
           ],
@@ -237,13 +244,13 @@ test('handles a batch of invocations with upload-api tracking capabilities', asy
     },
     // upload/remove
     {
-      carCid: cars[0].cid.toString(),
+      carCid: car.cid.toString(),
       value: {
           att: [
             UploadCapabilities.remove.create({
               with: spaceDid,
               nb: {
-                root: cars[0].cid,
+                root: blobs[0].cid,
               }
             })
           ],
@@ -256,14 +263,14 @@ test('handles a batch of invocations with upload-api tracking capabilities', asy
       },
       ts: Date.now() + 2
     },
-    // store/remove
+    // blob/remove
     {
-      carCid: cars[0].cid.toString(),
+      carCid: car.cid.toString(),
       value: {
-        att: cars.map((car) => StoreCapabilities.remove.create({
+        att: blobs.map((blob) => BlobCapabilities.remove.create({
           with: spaceDid,
           nb: {
-            link: car.cid,
+            digest: blob.digest,
           }
         })),
         aud: uploadService.did(),
@@ -280,23 +287,24 @@ test('handles a batch of invocations with upload-api tracking capabilities', asy
   // @ts-expect-error
   await updateAdminMetrics(invocations, {
     metricsStore: adminMetricsStore,
-    carStore
+    carStore,
+    allocationsStorage
   })
   const metricsTable = useMetricsGetTable(t.context.dynamo, t.context.adminMetricsTableName)
   const metrics = await getMetrics(metricsTable)
 
-  // `store/add`
-  t.deepEqual(metrics[METRICS_NAMES.STORE_ADD_TOTAL], cars.length)
-  t.deepEqual(metrics[METRICS_NAMES.STORE_ADD_SIZE_TOTAL], cars.reduce((acc, c) => {
+  // `blob/add`
+  t.deepEqual(metrics[METRICS_NAMES.BLOB_ADD_TOTAL], blobs.length)
+  t.deepEqual(metrics[METRICS_NAMES.BLOB_ADD_SIZE_TOTAL], blobs.reduce((acc, c) => {
     return acc + c.size
   }, 0))
   // `upload/add`
   t.deepEqual(metrics[METRICS_NAMES.UPLOAD_ADD_TOTAL], 1)
   // `upload/remove`
   t.deepEqual(metrics[METRICS_NAMES.UPLOAD_REMOVE_TOTAL], 1)
-  // `store/remove`
-  t.deepEqual(metrics[METRICS_NAMES.STORE_REMOVE_TOTAL], cars.length)
-  t.deepEqual(metrics[METRICS_NAMES.STORE_REMOVE_SIZE_TOTAL], cars.reduce((acc, c) => {
+  // `blob/remove`
+  t.deepEqual(metrics[METRICS_NAMES.BLOB_REMOVE_TOTAL], blobs.length)
+  t.deepEqual(metrics[METRICS_NAMES.BLOB_REMOVE_SIZE_TOTAL], blobs.reduce((acc, c) => {
     return acc + c.size
   }, 0))
 })

--- a/upload-api/test/helpers/context.js
+++ b/upload-api/test/helpers/context.js
@@ -18,6 +18,8 @@ import anyTest from 'ava'
  * @property {string} spaceMetricsTableName
  * @property {import('../../types').CarStore} carStore
  * @property {string} carStoreBucketName
+ * @property {import('@web3-storage/upload-api').AllocationsStorage} allocationsStorage
+ * @property {string} allocationsTableName
  *
  * @typedef {import("ava").TestFn<DynamoContext & S3Context & ServiceContext>} Test
  * @typedef {import("ava").TestFn<DynamoContext>} TestDynamo

--- a/upload-api/test/helpers/random.js
+++ b/upload-api/test/helpers/random.js
@@ -2,6 +2,7 @@ import { webcrypto } from 'crypto'
 import { Blob } from '@web-std/blob'
 import { CarWriter } from '@ipld/car'
 import { CID } from 'multiformats/cid'
+import * as Link from 'multiformats/link'
 import * as raw from 'multiformats/codecs/raw'
 import { sha256 } from 'multiformats/hashes/sha2'
 import * as CAR from '@ucanto/transport/car'
@@ -17,6 +18,17 @@ export async function randomBytes(size) {
     bytes.set(chunk, size)
   }
   return bytes
+}
+
+/** @param {number} size */
+export async function randomBlob(size) {
+  const bytes = await randomBytes(size)
+  const multihash = await sha256.digest(bytes)
+  const digest = multihash.bytes
+  const blobSize = bytes.byteLength
+  const cid = Link.create(raw.code, multihash)
+
+  return { digest, size: blobSize, cid }
 }
 
 export async function randomCID() {

--- a/upload-api/types.ts
+++ b/upload-api/types.ts
@@ -3,7 +3,7 @@ import { DID, Link, Delegation, Signature, Block, UCANLink, ByteView, DIDKey, Re
 import { UnknownLink } from 'multiformats'
 import { CID } from 'multiformats/cid'
 import { Kinesis } from '@aws-sdk/client-kinesis'
-import { AccountDID, ProviderDID, Service, SpaceDID, CarStoreBucket } from '@web3-storage/upload-api'
+import { AccountDID, ProviderDID, Service, SpaceDID, CarStoreBucket, AllocationsStorage } from '@web3-storage/upload-api'
 
 export interface StoreOperationError extends Error {
   name: 'StoreOperationFailed'
@@ -37,6 +37,7 @@ export interface MetricsStore {
 export interface MetricsCtx {
   metricsStore: MetricsStore
   carStore: CarStore
+  allocationsStorage: AllocationsStorage
 }
 
 export interface SpaceMetricsItem {
@@ -51,6 +52,7 @@ export interface SpaceMetricsStore {
 export interface SpaceMetricsCtx {
   metricsStore: SpaceMetricsStore
   carStore: CarStore
+  allocationsStorage: AllocationsStorage
 }
 
 export interface CarStore extends CarStoreBucket {


### PR DESCRIPTION
Adds blob metrics for admin and space to track:
- count `blob/add`
- sum `blob/add` (`nb.blob.size`)
- count `blob/remove`
- sum `blob/remove` allocated size