### PR TITLE
fix: ipni service configuration for non west 2 deployments

### DIFF
--- a/stacks/upload-api-stack.js
+++ b/stacks/upload-api-stack.js
@@ -61,6 +61,8 @@ export function UploadApiStack({ stack, app }) {
   const pkg = getApiPackageJson()
   const git = getGitInfo()
   const ucanInvocationPostbasicAuth = new Config.Secret(stack, 'UCAN_INVOCATION_POST_BASIC_AUTH')
+  // https://docs.aws.amazon.com/IAM/latest/UserGuide/reference-arns.html#arns-syntax
+  const indexerRegion = EIPFS_MULTIHASHES_SQS_ARN.split(':')[3]
 
   const api = new Api(stack, 'http-gateway', {
     customDomain,
@@ -141,7 +143,7 @@ export function UploadApiStack({ stack, app }) {
           STRIPE_PUBLISHABLE_KEY: process.env.STRIPE_PUBLISHABLE_KEY ?? '',
           DEAL_TRACKER_DID: process.env.DEAL_TRACKER_DID ?? '',
           DEAL_TRACKER_URL: process.env.DEAL_TRACKER_URL ?? '',
-          INDEXER_REGION: EIPFS_MULTIHASHES_SQS_ARN.includes('us-west-2') ? 'us-west-2' : 'us-east-2'
+          INDEXER_REGION: indexerRegion
         },
         bind: [
           privateKey,

--- a/stacks/upload-api-stack.js
+++ b/stacks/upload-api-stack.js
@@ -141,6 +141,7 @@ export function UploadApiStack({ stack, app }) {
           STRIPE_PUBLISHABLE_KEY: process.env.STRIPE_PUBLISHABLE_KEY ?? '',
           DEAL_TRACKER_DID: process.env.DEAL_TRACKER_DID ?? '',
           DEAL_TRACKER_URL: process.env.DEAL_TRACKER_URL ?? '',
+          INDEXER_REGION: EIPFS_MULTIHASHES_SQS_ARN.includes('us-west-2') ? 'us-west-2' : 'us-east-2'
         },
         bind: [
           privateKey,

--- a/upload-api/functions/ucan-invocation-router.js
+++ b/upload-api/functions/ucan-invocation-router.js
@@ -391,11 +391,11 @@ function getLambdaEnv () {
     // IPNI service
     multihashesQueueConfig: {
       url: new URL(mustGetEnv('MULTIHASHES_QUEUE_URL')),
-      region: mustGetEnv('AWS_REGION')
+      region: mustGetEnv('INDEXER_REGION')
     },
     blocksCarsPositionTableConfig: {
       name: mustGetEnv('BLOCKS_CAR_POSITION_TABLE_NAME'),
-      region: mustGetEnv('AWS_REGION')
+      region: mustGetEnv('INDEXER_REGION')
     },
     // set for testing
     dbEndpoint: process.env.DYNAMO_DB_ENDPOINT,


### PR DESCRIPTION
Yesterday I was puzzled on why my local deployment of Integration tests was working, while CI was not with some random errors just in few tests (with similar error as previous lack of permissions). It turns out, it was more lack of permissions, together with some bad configuration.

This extra permissions and configuration are actually a consequence of a different deployment approach per environment on w3up infra compared to old E-IPFS infra. Let's see the details:

w3up infra deployments:
- `prod` => `us-west-2`
- `dev` such as `vasco` => `us-west-2`
- `staging` => `us-east-2`
- `pr` such as `pr369` => `us-east-2`

E-IPFS infra deployments:
- `prod` => `us-west-2`
- `staging` => `us-west-2`

Considering the above, when we would be in prod or dev, both infras would be deployed in same zone. However, for staging and PR deployments, there would be a gap. Two problems needed to be addressed to make this work:
1. Actually the content of this PR, we were assuming E-IPFS infra was in `AWS_REGION` ENV VAR, which is the region current code is deployed at. I changed this to infer the region based on the provided ARN for these resources.
2. SQS is more tricky than DynamoDB, and does not support out of the box to communicate between zones, unless it is explicitly allowed in the policies. I manually set a policy in the SQS staging queue to allow this to happen https://us-west-2.console.aws.amazon.com/sqs/v3/home?region=us-west-2#/queues/https%3A%2F%2Fsqs.us-west-2.amazonaws.com%2F505595374361%2Fstaging-ep-multihashes-topic . Note that it guarantees that only lambdas running on this account can send messages through the queue. We should add this to the actual old infra setup, but I have no idea at this point on how to do it, and was hoping that @joaosa could help out on this one 🙏🏼 