### PR TITLE
fix: claim correct location

### DIFF
--- a/upload-api/external-services/ipni-service.js
+++ b/upload-api/external-services/ipni-service.js
@@ -43,7 +43,7 @@ export const useIPNIService = (blockAdvertPublisher, blockIndexStore, blobsStora
       for (const [digest, range] of shard.entries()) {
         items.push(digest)
 
-        const createUrlRes = await blobsStorage.createDownloadUrl(digest)
+        const createUrlRes = await blobsStorage.createDownloadUrl(digest.bytes)
         if (!createUrlRes.ok) return createUrlRes
 
         const location = new URL(createUrlRes.ok)

--- a/upload-api/functions/ucan-invocation-router.js
+++ b/upload-api/functions/ucan-invocation-router.js
@@ -207,7 +207,7 @@ export async function ucanInvocationRouter(request) {
     url: uploadServiceURL
   })
   const tasksScheduler = createTasksScheduler(() => selfConnection)
-  const ipniService = createIPNIService(multihashesQueueConfig, blocksCarsPositionTableConfig)
+  const ipniService = createIPNIService(multihashesQueueConfig, blocksCarsPositionTableConfig, blobsStorage)
 
   const server = createUcantoServer(serviceSigner, {
     codec,

--- a/upload-api/test/helpers/ipni-service.js
+++ b/upload-api/test/helpers/ipni-service.js
@@ -8,8 +8,9 @@ import { RecordNotFound } from '@web3-storage/upload-api/errors'
 
 /**
  * @param {{ sqs: import('@aws-sdk/client-sqs').SQSClient, dynamo: import('@aws-sdk/client-dynamodb').DynamoDBClient }} config
+ * @param {import('@web3-storage/upload-api').BlobsStorage} blobsStorage
  */
-export const createTestIPNIService = async ({ sqs, dynamo }) => {
+export const createTestIPNIService = async ({ sqs, dynamo }, blobsStorage) => {
   const queueURL = await createQueue(sqs, 'multihashes')
   const blockAdvertPublisher = new BlockAdvertisementPublisher({
     client: sqs,
@@ -24,7 +25,7 @@ export const createTestIPNIService = async ({ sqs, dynamo }) => {
 
   const messages = new Set()
   return Object.assign(
-    useIPNIService(blockAdvertPublisher, blockIndexStore),
+    useIPNIService(blockAdvertPublisher, blockIndexStore, blobsStorage),
     {
       /** @param {import('multiformats').MultihashDigest} digest */
       async query (digest) {

--- a/upload-api/test/helpers/ucan.js
+++ b/upload-api/test/helpers/ucan.js
@@ -287,7 +287,7 @@ export async function executionContextToUcantoTestServerContext(t) {
   const billingProvider = createTestBillingProvider()
   const plansStorage = usePlansStore(customersStore, billingProvider)
   const email = new DebugEmail();
-  const ipniService = await createTestIPNIService({ sqs, dynamo })
+  const ipniService = await createTestIPNIService({ sqs, dynamo }, blobsStorage)
 
   /** @type {import('@web3-storage/upload-api').UcantoServerContext} */
   const serviceContext = {


### PR DESCRIPTION
When IPNI service writes to dynamo, use the `BlobsStorage` to get the actual download URL for a given multihash.